### PR TITLE
Fix setup.[c]sh so can be sourced from anywhere

### DIFF
--- a/setup.csh
+++ b/setup.csh
@@ -15,8 +15,10 @@
 # Greet the user
 echo "Setting up environment for compiling/running SFrame"
 
-# speficy the SFRAME base directory, i.e. the directory in which this file lives
-setenv SFRAME_DIR ${PWD}
+# specify the SFRAME base directory, i.e. the directory in which this file lives
+# do it this way so it can be sourced from anywhere
+set rootdir = `dirname $0`       # may be relative path
+setenv SFRAME_DIR `cd $rootdir && pwd`    # ensure absolute path
 
 # Modify to describe your directory structure. Default is to use the a structure
 # where all directories are below the SFrame base directory specified above
@@ -58,4 +60,4 @@ endif
 setenv PATH ${SFRAME_BIN_PATH}:${PATH}
 setenv PYTHONPATH ${SFRAME_DIR}/python:${PYTHONPATH}
 
-setenv PAR_PATH ./:${SFRAME_LIB_PATH}
+setenv PAR_PATH ${SFRAME_DIR}/:${SFRAME_LIB_PATH}

--- a/setup.sh
+++ b/setup.sh
@@ -20,8 +20,9 @@ if [ $SFRAME_DIR ]; then
     return 1
 fi
 
-# speficy the SFRAME base directory, i.e. the directory in which this file lives
-export SFRAME_DIR=${PWD}
+# specify the SFRAME base directory, i.e. the directory in which this file lives
+# do it this way so it can be sourced from anywhere
+export SFRAME_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 # Modify to describe your directory structure. Default is to use the a structure where
 # all directories are below the SFrame base directory specified above
@@ -63,4 +64,4 @@ fi
 export PATH=${SFRAME_BIN_PATH}:${PATH}
 export PYTHONPATH=${SFRAME_DIR}/python:${PYTHONPATH}
 
-export PAR_PATH=./:${SFRAME_LIB_PATH}
+export PAR_PATH=${SFRAME_DIR}/:${SFRAME_LIB_PATH}


### PR DESCRIPTION
No need to `cd` into the SFrame dir anymore each time the user logs in.

Used
https://stackoverflow.com/questions/59895/getting-the-source-directory-of-a-bash-script-from-within
https://stackoverflow.com/questions/2563300/how-can-i-find-the-location-of-the-tcsh-shell-script-im-executing/
