### PR TITLE
Updates to work with gcc7

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+*.pcm
+*.pyc
+*_Dict.cxx
+
+bin
+lib
+obj
+

--- a/core/include/ISCycleBaseConfig.h
+++ b/core/include/ISCycleBaseConfig.h
@@ -40,7 +40,7 @@ public:
    virtual ~ISCycleBaseConfig() {}
 
    /// Function initialising the cycle
-   virtual void Initialize( TXMLNode* ) throw( SError ) = 0;
+   virtual void Initialize( TXMLNode* ) = 0;
 
    /// Get the full configuration of the cycle
    virtual const SCycleConfig& GetConfig() const = 0;

--- a/core/include/ISCycleBaseNTuple.h
+++ b/core/include/ISCycleBaseNTuple.h
@@ -59,20 +59,20 @@ public:
 
 protected:
    /// Function creating an output file on demand
-   virtual TDirectory* GetOutputFile() throw( SError ) = 0;
+   virtual TDirectory* GetOutputFile() = 0;
    /// Function closing a potentially open output file
-   virtual void CloseOutputFile() throw( SError ) = 0;
+   virtual void CloseOutputFile() = 0;
    /// Create the output trees
    virtual void
    CreateOutputTrees( const SInputData& id,
-                      std::vector< TTree* >& outTrees ) throw( SError ) = 0;
+                      std::vector< TTree* >& outTrees ) = 0;
    /// Save all the created output trees in the output
-   virtual void SaveOutputTrees() throw( SError ) = 0;
+   virtual void SaveOutputTrees() = 0;
    /// Load the input trees
    virtual void LoadInputTrees( const SInputData& id, TTree* main_tree,
-                                TDirectory*& inputFile ) throw( SError ) = 0;
+                                TDirectory*& inputFile ) = 0;
    /// Read in the event from the "normal" trees
-   virtual void GetEvent( Long64_t entry ) throw( SError ) = 0;
+   virtual void GetEvent( Long64_t entry ) = 0;
    /// Calculate the weight of the current event
    virtual Double_t CalculateWeight( const SInputData& inputData,
                                      Long64_t entry ) const = 0;

--- a/core/include/SCycleBaseConfig.h
+++ b/core/include/SCycleBaseConfig.h
@@ -52,7 +52,7 @@ public:
    SCycleBaseConfig();
 
    /// Function initialising the cycle
-   void Initialize( TXMLNode* ) throw( SError );
+   void Initialize( TXMLNode* );
 
    /// Get the overall cycle configuration object
    const SCycleConfig& GetConfig() const;
@@ -95,13 +95,13 @@ public:
 
 protected:
    /// Function that reads an InputData definition
-   virtual SInputData InitializeInputData( TXMLNode* ) throw( SError );
+   virtual SInputData InitializeInputData( TXMLNode* );
    /// Function that reads the user properties from the XML
-   virtual void InitializeUserConfig( TXMLNode* ) throw( SError );
+   virtual void InitializeUserConfig( TXMLNode* );
 
    /// Internal function for setting a property value
    void SetProperty( const std::string& name,
-                     const std::string& value ) throw( SError );
+                     const std::string& value );
 
    /// Function for decoding a shell environment variable
    std::string DecodeEnvVar( const std::string& value ) const; 
@@ -111,7 +111,7 @@ protected:
 
 private:
    /// Function for decoding a string to bool
-   bool ToBool( const std::string& value ) throw( SError );
+   bool ToBool( const std::string& value );
    /// Function used in constructing the user configuration options
    template< typename T >
    void AddUserOptions( const std::map< const std::string, T* >& prefs );

--- a/core/include/SCycleBaseExec.h
+++ b/core/include/SCycleBaseExec.h
@@ -93,32 +93,32 @@ public:
     * Analysis-wide configurations, like the setup of some reconstruction
     * algorithm based on properties configured in XML should be done here.
     */
-   virtual void BeginCycle() throw( SError ) = 0;
+   virtual void BeginCycle() = 0;
    /// Finalisation called at the end of a full cycle
    /**
     * This is the last function called after an analysis run, so it
     * could be a good place to print some statistics about the running.
     */
-   virtual void EndCycle() throw( SError ) = 0;
+   virtual void EndCycle() = 0;
    /// Initialisation called on the worker nodes for each input data type
    /**
     * This is the place to declare the output variables for the output
     * TTree(s). This is also the earliest point where histograms can
     * be created.
     */
-   virtual void BeginInputData( const SInputData& ) throw( SError ) = 0;
+   virtual void BeginInputData( const SInputData& ) = 0;
    /// Finalisation called on the worker nodes for each input data type
    /**
     * Mainly used for printing input data statistics, or normalising
     * efficiency histograms by hand.
     */
-   virtual void EndInputData  ( const SInputData& ) throw( SError ) = 0;
+   virtual void EndInputData  ( const SInputData& ) = 0;
    /// Initialisation called for each input file
    /**
     * This is the place to connect the input variables to the branches
     * of the input tree(s).
     */
-   virtual void BeginInputFile( const SInputData& ) throw( SError ) = 0;
+   virtual void BeginInputFile( const SInputData& ) = 0;
    /// Function called for every event
    /**
     * This is the function where the main analysis should be done. By the
@@ -126,7 +126,7 @@ public:
     * contents of the actual event.
     */
    virtual void ExecuteEvent( const SInputData&,
-                              Double_t weight ) throw( SError ) = 0;
+                              Double_t weight ) = 0;
    //@}
 
    /// @name Functions that are optional to be implemented is user code
@@ -136,18 +136,18 @@ public:
     * This function is mostly a placeholder for now. There is not much one
     * can do here yet...
     */
-   virtual void BeginMasterInputData( const SInputData& ) throw( SError ) {}
+   virtual void BeginMasterInputData( const SInputData& ) {}
    /// Finalisation called on the client machine for each input data type
    /**
     * This function is mostly a placeholder for now. There is not much one
     * can do here yet...
     */
-   virtual void EndMasterInputData( const SInputData& ) throw( SError ) {}
+   virtual void EndMasterInputData( const SInputData& ) {}
    //@}
 
 private:
    /// Function for reading the cycle configuration on the worker nodes
-   void ReadConfig() throw( SError );
+   void ReadConfig();
    /// Dummy override for the function defined in TObject
    virtual void ExecuteEvent( Int_t event, Int_t px, Int_t py );
 

--- a/core/include/SCycleBaseHist.h
+++ b/core/include/SCycleBaseHist.h
@@ -62,22 +62,22 @@ public:
    /// Function placing a ROOT object in the output file
    template< class T > T* Book( const T& histo,
                                 const char* directory = 0,
-                                Bool_t inFile = kFALSE ) throw( SError );
+                                Bool_t inFile = kFALSE );
    /// Function searching for a ROOT object in the output file
    template< class T > T* Retrieve( const char* name,
                                     const char* directory = 0,
-                                    Bool_t outputOnly = kFALSE ) throw( SError );
+                                    Bool_t outputOnly = kFALSE );
    /// Function retrieving all ROOT objects of this name from the input file
    template< class T >
    std::vector< T* > RetrieveAll( const char* name,
-                                  const char* directory = 0 ) throw( SError );
+                                  const char* directory = 0 );
    /// Function for persistifying a ROOT object to the output
    void WriteObj( const TObject& obj,
                   const char* directory = 0,
-                  Bool_t inFile = kFALSE ) throw( SError );
+                  Bool_t inFile = kFALSE );
 
    /// Function searching for 1-dimensional histograms in the output file
-   TH1* Hist( const char* name, const char* dir = 0 ) throw( SError );
+   TH1* Hist( const char* name, const char* dir = 0 );
 
 protected:
    /// Set the current input file

--- a/core/include/SCycleBaseHist.icc
+++ b/core/include/SCycleBaseHist.icc
@@ -50,7 +50,7 @@
 template< class T >
 T* SCycleBaseHist::Book( const T& histo,
                          const char* directory,
-                         Bool_t inFile ) throw( SError ) {
+                         Bool_t inFile ) {
 
    // Put the object into our temporary directory in memory:
    GetTempDir()->cd();
@@ -128,7 +128,7 @@ T* SCycleBaseHist::Book( const T& histo,
 template< class T >
 T* SCycleBaseHist::Retrieve( const char* name,
                              const char* directory,
-                             Bool_t outputOnly ) throw( SError ) {
+                             Bool_t outputOnly ) {
 
    // Just to make sure that we're in the default directory in
    // memory:
@@ -229,7 +229,7 @@ T* SCycleBaseHist::Retrieve( const char* name,
 template< class T >
 std::vector< T* >
 SCycleBaseHist::RetrieveAll( const char* name,
-                             const char* directory ) throw( SError ) {
+                             const char* directory ) {
 
    // The result object:
    std::vector< T* > result;

--- a/core/include/SCycleBaseNTuple.h
+++ b/core/include/SCycleBaseNTuple.h
@@ -66,33 +66,33 @@ public:
    /// Connect an input variable
    template< typename T >
    bool ConnectVariable( const char* treeName, const char* branchName,
-                         T& variable ) throw ( SError );
+                         T& variable );
    /// Specialisation for primitive arrays
    template< typename T, size_t size >
    bool ConnectVariable( const char* treeName, const char* branchName,
-                         T ( &variable )[ size ] ) throw( SError );
+                         T ( &variable )[ size ] );
    /// Specialisation for object pointers
    template< typename T >
    bool ConnectVariable( const char* treeName, const char* branchName,
-                         T*& variable ) throw( SError );
+                         T*& variable );
 
    /// Declare an output variable
    template< class T >
    TBranch* DeclareVariable( T& obj, const char* name,
-                             const char* treeName = 0 ) throw( SError );
+                             const char* treeName = 0 );
 
    /// Access one of the metadata trees
-   virtual TTree* GetMetadataTree( const char* name ) const throw( SError );
+   virtual TTree* GetMetadataTree( const char* name ) const;
    /// Access one of the input metadata trees
    virtual TTree*
-   GetInputMetadataTree( const char* name ) const throw( SError );
+   GetInputMetadataTree( const char* name ) const;
    /// Access one of the output metadata trees
    virtual TTree*
-   GetOutputMetadataTree( const char* name ) const throw( SError );
+   GetOutputMetadataTree( const char* name ) const;
    /// Access one of the input trees
-   virtual TTree* GetInputTree( const char* treeName ) const throw( SError );
+   virtual TTree* GetInputTree( const char* treeName ) const;
    /// Access one of the output trees
-   virtual TTree* GetOutputTree( const char* treeName ) const throw( SError );
+   virtual TTree* GetOutputTree( const char* treeName ) const;
 
 protected:
    //////////////////////////////////////////////////////////
@@ -102,19 +102,19 @@ protected:
    //////////////////////////////////////////////////////////
 
    /// Function creating an output file on demand
-   virtual TDirectory* GetOutputFile() throw( SError );
+   virtual TDirectory* GetOutputFile();
    /// Function closing a potentially open output file
-   virtual void CloseOutputFile() throw( SError );
+   virtual void CloseOutputFile();
    /// Create the output trees
    void CreateOutputTrees( const SInputData& id,
-                           std::vector< TTree* >& outTrees ) throw( SError );
+                           std::vector< TTree* >& outTrees );
    /// Save all the created output trees in the output
-   void SaveOutputTrees() throw( SError );
+   void SaveOutputTrees();
    /// Load the input trees
    void LoadInputTrees( const SInputData& id, TTree* main_tree,
-                        TDirectory*& inputFile ) throw( SError );
+                        TDirectory*& inputFile );
    /// Read in the event from the "normal" trees
-   void GetEvent( Long64_t entry ) throw( SError );
+   void GetEvent( Long64_t entry );
    /// Calculate the weight of the current event
    Double_t CalculateWeight( const SInputData& inputData,
                              Long64_t entry ) const;
@@ -123,16 +123,16 @@ protected:
 
 private:
    /// Function translating a "typeid type" into a ROOT type character
-   static const char* RootType( const char* typeid_type ) throw( SError );
+   static const char* RootType( const char* typeid_type );
    /// Function translating a ROOT type character into a "typeid type"
-   static const char* TypeidType( const char* root_type ) throw( SError );
+   static const char* TypeidType( const char* root_type );
    /// Function registering an input branch for use during the event loop
-   void RegisterInputBranch( TBranch* br ) throw( SError );
+   void RegisterInputBranch( TBranch* br );
    /// Function deleting the object created on the heap by ROOT
    void DeleteInputVariables();
    /// Function creating a sub-directory inside an existing directory
    TDirectory* MakeSubDirectory( const TString& path,
-                                 TDirectory* dir ) const throw( SError );
+                                 TDirectory* dir ) const;
 
    //
    // These are the objects used to handle the input and output data:

--- a/core/include/SCycleBaseNTuple.icc
+++ b/core/include/SCycleBaseNTuple.icc
@@ -55,7 +55,7 @@
 template< typename T >
 bool SCycleBaseNTuple::ConnectVariable( const char* treeName,
                                         const char* branchName,
-                                        T& variable ) throw ( SError ) {
+                                        T& variable ) {
 
    REPORT_VERBOSE( "Called with treeName = \"" << treeName
                    << "\", branchName = \"" << branchName << "\"" );
@@ -203,7 +203,7 @@ bool SCycleBaseNTuple::ConnectVariable( const char* treeName,
 template< typename T, size_t size >
 bool SCycleBaseNTuple::
 ConnectVariable( const char* treeName, const char* branchName,
-                 T ( &variable )[ size ] ) throw( SError ) {
+                 T ( &variable )[ size ] ) {
 
    // Access the TTree. The function will throw an exception if unsuccessful
    TTree* tree = GetInputTree( treeName );
@@ -268,7 +268,7 @@ ConnectVariable( const char* treeName, const char* branchName,
 template< typename T >
 bool SCycleBaseNTuple::ConnectVariable( const char* treeName,
                                         const char* branchName,
-                                        T*& variable ) throw ( SError ) {
+                                        T*& variable ) {
 
    // Access the TTree. The function will throw an exception if unsuccessful
    TTree* tree = GetInputTree( treeName );
@@ -345,7 +345,7 @@ bool SCycleBaseNTuple::ConnectVariable( const char* treeName,
 template < class T >
 TBranch* SCycleBaseNTuple::
 DeclareVariable( T& obj, const char* name,
-                 const char* treeName ) throw( SError ) {
+                 const char* treeName ) {
 
    TTree*   tree = 0;
    TBranch* branch = 0;

--- a/core/include/SCycleConfig.h
+++ b/core/include/SCycleConfig.h
@@ -150,7 +150,7 @@ public:
    /// Print the configuration to the screen
    void PrintConfig() const;
    /// Re-arrange the input data objects
-   void ArrangeInputData() throw ( SError );
+   void ArrangeInputData();
    /// Fill the input data objects with information from the files
    void ValidateInput();
 

--- a/core/include/SCycleController.h
+++ b/core/include/SCycleController.h
@@ -51,11 +51,11 @@ public:
    virtual ~SCycleController();
 
    /// Initialise the analysis from the configuration file
-   virtual void Initialize() throw( SError );
+   virtual void Initialize();
    /// Execute the analysis loop for all configured cycles
-   virtual void ExecuteAllCycles() throw( SError );
+   virtual void ExecuteAllCycles();
    /// Execute the analysis loop for the cycle next in line
-   virtual void ExecuteNextCycle() throw( SError );
+   virtual void ExecuteNextCycle();
    /// Set the name of the configuration file
    /**
     * All configuration of the analysis is done in a single XML file.

--- a/core/include/SCycleOutput.h
+++ b/core/include/SCycleOutput.h
@@ -70,7 +70,7 @@ public:
 
 private:
    /// Return the requested output directory
-   TDirectory* MakeDirectory( const TString& path ) const throw( SError );
+   TDirectory* MakeDirectory( const TString& path ) const;
 
    /// The object that this class wraps
    TObject* m_object;

--- a/core/include/SError.h
+++ b/core/include/SError.h
@@ -45,24 +45,24 @@ public:
    };
 
    /// Constructor specifying only a severity
-   SError( Severity severity = SkipEvent ) throw();
+   SError( Severity severity = SkipEvent );
    /// Constructor with description and severity
-   SError( const char* description, Severity severity = SkipEvent ) throw();
+   SError( const char* description, Severity severity = SkipEvent );
    /// Copy constructor
-   SError( const SError& parent ) throw();
+   SError( const SError& parent );
 
    /// Destructor
-   virtual ~SError() throw();
+   virtual ~SError();
 
    /// Set the description of the exception
-   void SetDescription( const char* description ) throw();
+   void SetDescription( const char* description );
    /// Set the severity of the exception
-   void SetSeverity( Severity severity ) throw();
+   void SetSeverity( Severity severity );
 
    /// Get the description of the exception
-   virtual const char* what()    const throw();
+   virtual const char* what()    const noexcept;
    /// Get the severity of the exception
-   virtual Severity    request() const throw();
+   virtual Severity    request() const;
 
    /// Function to get the std::ostream functionality
    /**

--- a/core/include/SFileMerger.h
+++ b/core/include/SFileMerger.h
@@ -52,21 +52,21 @@ public:
    ~SFileMerger();
 
    /// Add an input file that should be processed
-   Bool_t AddFile( const TString& fileName ) throw( SError );
+   Bool_t AddFile( const TString& fileName );
    /// Specify the output of the merging
    Bool_t OutputFile( const TString& fileName,
-                      const TString& mode = "UPDATE" ) throw( SError );
+                      const TString& mode = "UPDATE" );
 
    /// Execute the merging itself
-   Bool_t Merge() throw( SError );
+   Bool_t Merge();
 
 private:
    /// Close all open files
    void CloseFiles();
    /// Merge the contents of one directory
-   void MergeDirectory( TDirectory* input, TDirectory* output ) throw( SError );
+   void MergeDirectory( TDirectory* input, TDirectory* output );
    /// Merge two objects together
-   void MergeObjects( TObject* in, TObject* out ) throw( SError );
+   void MergeObjects( TObject* in, TObject* out );
 
    std::vector< TFile* > m_inputFiles; ///< List of all specified input files
    TFile*                m_outputFile; ///< The output file

--- a/core/include/SInputData.h
+++ b/core/include/SInputData.h
@@ -253,7 +253,7 @@ public:
    void AddEvents( Long64_t events ) { m_eventsTotal += events; }
 
    /// Collect information about the input files (needed before running)
-   void ValidateInput( const char* pserver = 0 ) throw( SError );
+   void ValidateInput( const char* pserver = 0 );
 
    /// Get the name of the input data type
    const TString& GetType() const { return m_type; }
@@ -308,15 +308,15 @@ public:
 
 private:
    /// This function validates the input when files are specified
-   void ValidateInputFiles() throw( SError );
+   void ValidateInputFiles();
    /// This function validates the input when PQ2 datasets are specified
-   void ValidateInputDataSets( const char* pserver ) throw( SError );
+   void ValidateInputDataSets( const char* pserver );
    /// Function loading all information about a given input file
    Bool_t LoadInfoOnFile( SFile* file, TFileCollection* filecoll );
    /// Function accessing the metadata about a given input file
    TFileInfo* AccessFileInfo( SFile* file, TFileCollection* filecoll );
    /// Function creating a new dataset object for this input data object
-   TDSet* MakeDataSet() const throw( SError );
+   TDSet* MakeDataSet() const;
    /// Function trying to access the dataset object in a given directory
    TDSet* AccessDataSet( TDirectory* dir ) const;
 

--- a/core/include/SProofManager.h
+++ b/core/include/SProofManager.h
@@ -58,12 +58,12 @@ public:
 
    /// Function to open/access a PROOF connection
    TProof* Open( const TString& url,
-                 const TString& param = "" ) throw( SError );
+                 const TString& param = "" );
    /// Function to check if a PROOF server connection is configured already
    Bool_t IsConfigured( const TString& url, const TString& param = "" ) const;
    /// Set a given PROOF server to "configured" state
    void SetConfigured( const TString& url, const TString& param = "",
-                       Bool_t state = kTRUE ) throw( SError );
+                       Bool_t state = kTRUE );
    /// Function deleting all the open PROOF connections
    void Cleanup();
 

--- a/core/src/SCycleBaseConfig.cxx
+++ b/core/src/SCycleBaseConfig.cxx
@@ -100,7 +100,7 @@ SCycleBaseConfig::SCycleBaseConfig()
  *
  * @param node The top XML node describing the cycle
  */
-void SCycleBaseConfig::Initialize( TXMLNode* node ) throw( SError ) {
+void SCycleBaseConfig::Initialize( TXMLNode* node ) {
 
    m_logger << INFO << "Initializing from configuration" << SLogger::endmsg;
 
@@ -423,7 +423,7 @@ TObject* SCycleBaseConfig::GetConfigObject( const char* name ) const {
 ///////////////////////////////////////////////////////////////////////////
 
 SInputData
-SCycleBaseConfig::InitializeInputData( TXMLNode* node ) throw( SError ) {
+SCycleBaseConfig::InitializeInputData( TXMLNode* node ) {
 
    // Create the SInputData object
    SInputData inputData;
@@ -605,7 +605,7 @@ SCycleBaseConfig::InitializeInputData( TXMLNode* node ) throw( SError ) {
    return inputData;
 }
 
-void SCycleBaseConfig::InitializeUserConfig( TXMLNode* node ) throw( SError ) {
+void SCycleBaseConfig::InitializeUserConfig( TXMLNode* node ) {
 
    REPORT_VERBOSE( "Initializing the user configuration" );
 
@@ -658,7 +658,7 @@ void SCycleBaseConfig::InitializeUserConfig( TXMLNode* node ) throw( SError ) {
 
 void SCycleBaseConfig::
 SetProperty( const std::string& name,
-             const std::string& stringValue ) throw( SError ) {
+             const std::string& stringValue ) {
 
    // Check if the user is specifying the same property multiple times.
    // XML doesn't guarantee in which order the properties are getting
@@ -782,7 +782,7 @@ std::string SCycleBaseConfig::DecodeEnvVar( const std::string& value ) const {
  * @param value The string to be interpreted as a boolean value
  * @returns A boolean value made from the string
  */
-bool SCycleBaseConfig::ToBool( const std::string& value ) throw( SError ) {
+bool SCycleBaseConfig::ToBool( const std::string& value ) {
 
    // The decoding is done using TString:
    TString tvalue( value );

--- a/core/src/SCycleBaseExec.cxx
+++ b/core/src/SCycleBaseExec.cxx
@@ -351,7 +351,7 @@ void SCycleBaseExec::Terminate() {
  * This function takes care of accessing the cycle configuration objects on the
  * master and worker nodes.
  */
-void SCycleBaseExec::ReadConfig() throw( SError ) {
+void SCycleBaseExec::ReadConfig() {
 
    //
    // Read the overall cycle configuration:

--- a/core/src/SCycleBaseHist.cxx
+++ b/core/src/SCycleBaseHist.cxx
@@ -67,7 +67,7 @@ TSelectorList* SCycleBaseHist::GetHistOutput() const {
  */
 void SCycleBaseHist::WriteObj( const TObject& obj,
                                const char* directory,
-                               Bool_t inFile ) throw( SError ) {
+                               Bool_t inFile ) {
 
    // Put the object into our temporary directory in memory:
    GetTempDir()->cd();
@@ -131,7 +131,7 @@ void SCycleBaseHist::WriteObj( const TObject& obj,
  * @param name The name of the histogram
  * @param dir  The name of the directory the histogram is in
  */
-TH1* SCycleBaseHist::Hist( const char* name, const char* dir ) throw( SError ) {
+TH1* SCycleBaseHist::Hist( const char* name, const char* dir ) {
 
    TH1* result;
 

--- a/core/src/SCycleBaseNTuple.cxx
+++ b/core/src/SCycleBaseNTuple.cxx
@@ -100,7 +100,7 @@ TList* SCycleBaseNTuple::GetNTupleInput() const {
  * @returns The pointer to the requested metadata tree
  */
 TTree* SCycleBaseNTuple::
-GetMetadataTree( const char* name ) const throw( SError ) {
+GetMetadataTree( const char* name ) const {
 
    // The result tree:
    TTree* result = 0;
@@ -154,7 +154,7 @@ GetMetadataTree( const char* name ) const throw( SError ) {
  * @returns The pointer to the requested metadata tree
  */
 TTree* SCycleBaseNTuple::
-GetInputMetadataTree( const char* name ) const throw( SError ) {
+GetInputMetadataTree( const char* name ) const {
 
    //
    // Strip off the directory name from the given tree name:
@@ -203,7 +203,7 @@ GetInputMetadataTree( const char* name ) const throw( SError ) {
  * @returns The pointer to the requested metadata tree
  */
 TTree* SCycleBaseNTuple::
-GetOutputMetadataTree( const char* name ) const throw( SError ) {
+GetOutputMetadataTree( const char* name ) const {
 
    //
    // Strip off the directory name from the given tree name:
@@ -252,7 +252,7 @@ GetOutputMetadataTree( const char* name ) const throw( SError ) {
  * @returns A pointer to the requested input tree if successful
  */
 TTree* SCycleBaseNTuple::
-GetInputTree( const char* treeName ) const throw( SError ) {
+GetInputTree( const char* treeName ) const {
 
    //
    // Look for such input tree:
@@ -288,7 +288,7 @@ GetInputTree( const char* treeName ) const throw( SError ) {
  * @return The pointer to the TTree if successful
  */
 TTree* SCycleBaseNTuple::
-GetOutputTree( const char* treeName ) const throw( SError ) {
+GetOutputTree( const char* treeName ) const {
 
    //
    // Look for such output tree:
@@ -324,7 +324,7 @@ GetOutputTree( const char* treeName ) const throw( SError ) {
  * @return A pointer to the output file's directory if successful, a null
  *         pointer if not
  */
-TDirectory* SCycleBaseNTuple::GetOutputFile() throw( SError ) {
+TDirectory* SCycleBaseNTuple::GetOutputFile() {
 
    // Return right away if we already have an output file opened:
    if( m_outputFile ) return m_outputFile;
@@ -426,7 +426,7 @@ TDirectory* SCycleBaseNTuple::GetOutputFile() throw( SError ) {
  * This function is called at the end of processing an input data block, to
  * save all the output trees, and close the output file properly.
  */
-void SCycleBaseNTuple::CloseOutputFile() throw( SError ) {
+void SCycleBaseNTuple::CloseOutputFile() {
 
    // We only need to do anything if the output file has been made:
    if( m_outputFile ) {
@@ -463,7 +463,7 @@ void SCycleBaseNTuple::CloseOutputFile() throw( SError ) {
  */
 void SCycleBaseNTuple::
 CreateOutputTrees( const SInputData& iD,
-                   std::vector< TTree* >& outTrees ) throw( SError ) {
+                   std::vector< TTree* >& outTrees ) {
 
    // sanity checks
    if( outTrees.size() ) {
@@ -623,7 +623,7 @@ CreateOutputTrees( const SInputData& iD,
  * deletes the TTree objects, so it should really only be called by the
  * framework at the end of processing.
  */
-void SCycleBaseNTuple::SaveOutputTrees() throw( SError ) {
+void SCycleBaseNTuple::SaveOutputTrees() {
 
    // Remember which directory we were in:
    TDirectory* savedir = gDirectory;
@@ -687,7 +687,7 @@ void SCycleBaseNTuple::SaveOutputTrees() throw( SError ) {
 void SCycleBaseNTuple::
 LoadInputTrees( const SInputData& iD,
                 TTree* main_tree,
-                TDirectory*& inputFile ) throw( SError ) {
+                TDirectory*& inputFile ) {
 
    REPORT_VERBOSE( "Loading/accessing the event-level input trees" );
 
@@ -819,7 +819,7 @@ LoadInputTrees( const SInputData& iD,
  *
  * @param entry The event number to read in
  */
-void SCycleBaseNTuple::GetEvent( Long64_t entry ) throw( SError ) {
+void SCycleBaseNTuple::GetEvent( Long64_t entry ) {
 
    // Tell all trees to update their cache:
    for( std::vector< TTree* >::const_iterator it = m_inputTrees.begin();
@@ -945,7 +945,7 @@ void SCycleBaseNTuple::ClearCachedTrees() {
  * @returns The primitive type name in ROOT's format
  */
 const char*
-SCycleBaseNTuple::RootType( const char* typeid_type ) throw( SError ) {
+SCycleBaseNTuple::RootType( const char* typeid_type ) {
 
    // Check that we received a reasonable input:
    if( strlen( typeid_type ) != 1 ) {
@@ -1013,7 +1013,7 @@ SCycleBaseNTuple::RootType( const char* typeid_type ) throw( SError ) {
  * @returns The typeid type name for the ROOT primitive type
  */
 const char*
-SCycleBaseNTuple::TypeidType( const char* root_type ) throw( SError ) {
+SCycleBaseNTuple::TypeidType( const char* root_type ) {
 
    // Do the hard-coded translation:
    if( ! strcmp( root_type, "Char_t" ) ) {
@@ -1054,7 +1054,7 @@ SCycleBaseNTuple::TypeidType( const char* root_type ) throw( SError ) {
  *
  * @param br The branch to remember
  */
-void SCycleBaseNTuple::RegisterInputBranch( TBranch* br ) throw( SError ) {
+void SCycleBaseNTuple::RegisterInputBranch( TBranch* br ) {
 
    // This is a bit slow, but still not the worst part of the code...
    if( std::find( m_inputBranches.begin(), m_inputBranches.end(), br ) !=
@@ -1096,7 +1096,7 @@ void SCycleBaseNTuple::DeleteInputVariables() {
  */
 TDirectory*
 SCycleBaseNTuple::MakeSubDirectory( const TString& path,
-                                    TDirectory* dir ) const throw( SError ) {
+                                    TDirectory* dir ) const {
 
    // Return the parent directory if the path name is empty:
    if( ! path.Length() ) return dir;

--- a/core/src/SCycleConfig.cxx
+++ b/core/src/SCycleConfig.cxx
@@ -345,7 +345,7 @@ void SCycleConfig::PrintConfig() const {
  * After the re-arranging the objects with the same type will end up
  * beside each other.
  */
-void SCycleConfig::ArrangeInputData() throw ( SError ) {
+void SCycleConfig::ArrangeInputData() {
 
    // multimap to hold all type strings of InputData objects; will be
    // used to search InputData objects with the same name, to make

--- a/core/src/SCycleController.cxx
+++ b/core/src/SCycleController.cxx
@@ -90,7 +90,7 @@ SCycleController::~SCycleController() {
  *
  * @callgraph
  */
-void SCycleController::Initialize() throw( SError ) {
+void SCycleController::Initialize() {
 
    m_logger << INFO << "Initializing" << SLogger::endmsg;
 
@@ -351,7 +351,7 @@ void SCycleController::Initialize() throw( SError ) {
  * @see SCycleController::ExecuteNextCycle
  * @callgraph
  */
-void SCycleController::ExecuteAllCycles() throw( SError ) {
+void SCycleController::ExecuteAllCycles() {
 
    // A little sanity check:
    if( ! m_isInitialized ) {
@@ -378,7 +378,7 @@ void SCycleController::ExecuteAllCycles() throw( SError ) {
  *
  * @callgraph
  */
-void SCycleController::ExecuteNextCycle() throw( SError ) {
+void SCycleController::ExecuteNextCycle() {
 
    // A little sanity check:
    if( ! m_isInitialized ) {

--- a/core/src/SCycleOutput.cxx
+++ b/core/src/SCycleOutput.cxx
@@ -294,7 +294,7 @@ Int_t SCycleOutput::Write( const char* name, Int_t option,
  * @returns Pointer to the created directory
  */
 TDirectory*
-SCycleOutput::MakeDirectory( const TString& path ) const throw( SError ) {
+SCycleOutput::MakeDirectory( const TString& path ) const {
 
    if( ! path.Length() ) return gDirectory;
 

--- a/core/src/SError.cxx
+++ b/core/src/SError.cxx
@@ -21,7 +21,7 @@
  *
  * @param severity The action request of the exception
  */
-SError::SError( Severity severity ) throw()
+SError::SError( Severity severity )
    : std::exception(), std::ostringstream(), m_severity( severity ) {
 
 }
@@ -38,7 +38,7 @@ SError::SError( Severity severity ) throw()
  * @param description Explanation for the occurance
  * @param severity    The action request of the exception
  */
-SError::SError( const char* description, Severity severity ) throw()
+SError::SError( const char* description, Severity severity )
    : std::exception(), std::ostringstream(), m_severity( severity ) {
 
    this->str( description );
@@ -51,7 +51,7 @@ SError::SError( const char* description, Severity severity ) throw()
  *
  * @param parent The object to clone
  */
-SError::SError( const SError& parent ) throw()
+SError::SError( const SError& parent )
    : std::basic_ios< SError::char_type, SError::traits_type >(),
      std::exception(), std::ostringstream(), m_severity( parent.m_severity ) {
 
@@ -64,7 +64,7 @@ SError::SError( const SError& parent ) throw()
  * doesn't declare that it may throw (an) exception(s), and this is an
  * error on most compilers.
  */
-SError::~SError() throw() {
+SError::~SError() {
 
 }
 
@@ -72,7 +72,7 @@ SError::~SError() throw() {
  * @param description The description that should be associated with this
  *                    exception
  */
-void SError::SetDescription( const char* description ) throw() {
+void SError::SetDescription( const char* description ) {
 
    this->str( description );
    return;
@@ -82,7 +82,7 @@ void SError::SetDescription( const char* description ) throw() {
  * @param severity The action that should be taken as the effect of this
  *                 exception
  */
-void SError::SetSeverity( Severity severity ) throw() {
+void SError::SetSeverity( Severity severity ) {
 
    m_severity = severity;
    return;
@@ -94,7 +94,7 @@ void SError::SetSeverity( Severity severity ) throw() {
  *
  * @returns An explanation about the exception
  */
-const char* SError::what() const throw() {
+const char* SError::what() const noexcept {
 
    return this->str().c_str();
 }
@@ -102,7 +102,7 @@ const char* SError::what() const throw() {
 /**
  * @returns The action that should be taken because of this exception
  */
-SError::Severity SError::request() const throw() {
+SError::Severity SError::request() const {
 
    return m_severity;
 }

--- a/core/src/SFileMerger.cxx
+++ b/core/src/SFileMerger.cxx
@@ -46,7 +46,7 @@ SFileMerger::~SFileMerger() {
  * @returns <code>kTRUE</code> if everything went correctly,
  *          <code>kFALSE</code> otherwise
  */
-Bool_t SFileMerger::AddFile( const TString& fileName ) throw( SError ) {
+Bool_t SFileMerger::AddFile( const TString& fileName ) {
 
    //
    // Copy the file locally. This is important when reading an ntuple file
@@ -92,7 +92,7 @@ Bool_t SFileMerger::AddFile( const TString& fileName ) throw( SError ) {
  *          <code>kFALSE</code> otherwise
  */
 Bool_t SFileMerger::OutputFile( const TString& fileName,
-                                const TString& mode ) throw( SError ) {
+                                const TString& mode ) {
 
    //
    // Try to open the specified output file. Throw an expection in case of
@@ -121,7 +121,7 @@ Bool_t SFileMerger::OutputFile( const TString& fileName,
  * @returns <code>kTRUE</code> if the merge was successful, <code>kFALSE</code>
  *          otherwise
  */
-Bool_t SFileMerger::Merge() throw( SError ) {
+Bool_t SFileMerger::Merge() {
 
    //
    // Check that we have both input(s) and an output:
@@ -192,7 +192,7 @@ void SFileMerger::CloseFiles() {
  * @param output The output directory
  */
 void SFileMerger::MergeDirectory( TDirectory* input,
-                                  TDirectory* output ) throw( SError ) {
+                                  TDirectory* output ) {
 
    // Get a list of all objects in this directory:
    TList* keyList = input->GetListOfKeys();
@@ -364,7 +364,7 @@ void SFileMerger::MergeDirectory( TDirectory* input,
  * @param in The input object
  * @param out The object into which the input object should be merged
  */
-void SFileMerger::MergeObjects( TObject* in, TObject* out ) throw( SError ) {
+void SFileMerger::MergeObjects( TObject* in, TObject* out ) {
 
    // Put the input object into a list:
    TList list;

--- a/core/src/SInputData.cxx
+++ b/core/src/SInputData.cxx
@@ -258,7 +258,7 @@ void SInputData::AddDataSet( const SDataSet& dset ) {
  *
  * @param pserver Name of the PROOF server to use in the validation
  */
-void SInputData::ValidateInput( const char* pserver ) throw( SError ) {
+void SInputData::ValidateInput( const char* pserver ) {
 
    // Check that the user only specified one type of input:
    if( GetSFileIn().size() && GetDataSets().size() ) {
@@ -623,7 +623,7 @@ TString SInputData::GetStringConfig() const {
  * This function looks at all the specified input files to make sure that they
  * exist, and to extract information about the trees inside of them.
  */
-void SInputData::ValidateInputFiles() throw( SError ) {
+void SInputData::ValidateInputFiles() {
 
    //
    // Set up the connection to the InputData cache if it's asked for:
@@ -905,7 +905,7 @@ void SInputData::ValidateInputFiles() throw( SError ) {
  *
  * @param pserver The PROOF server to use in the validation
  */
-void SInputData::ValidateInputDataSets( const char* pserver ) throw( SError ) {
+void SInputData::ValidateInputDataSets( const char* pserver ) {
 
    // Connect to the PROOF server:
    TProof* server = SProofManager::Instance()->Open( pserver );
@@ -1148,7 +1148,7 @@ TFileInfo* SInputData::AccessFileInfo( SFile* file,
  *
  * @returns A validated dataset made from the input files
  */
-TDSet* SInputData::MakeDataSet() const throw( SError ) {
+TDSet* SInputData::MakeDataSet() const {
 
    // Find the name of the "main" TTree in the files:
    const char* treeName = 0;

--- a/core/src/SProofManager.cxx
+++ b/core/src/SProofManager.cxx
@@ -73,7 +73,7 @@ SProofManager* SProofManager::Instance() {
  * @returns The created TProof object
  */
 TProof* SProofManager::Open( const TString& url,
-                             const TString& param ) throw( SError ) {
+                             const TString& param ) {
 
    // Copy the contents of the parameters, as we may have to change them:
    TString urlcopy( url );
@@ -212,7 +212,7 @@ Bool_t SProofManager::IsConfigured( const TString& url,
  */
 void SProofManager::SetConfigured( const TString& url,
                                    const TString& param,
-                                   Bool_t state ) throw( SError ) {
+                                   Bool_t state ) {
 
    // Make sure the connection is open. This call can throw an error
    // if unsuccessful, so no point in checking its return value.

--- a/plug-ins/include/SH1.h
+++ b/plug-ins/include/SH1.h
@@ -63,7 +63,7 @@ public:
    virtual ~SH1();
 
    /// Increase the contents of the bin at a specific position
-   void Fill( Double_t pos, Type weight = 1 ) throw( SError );
+   void Fill( Double_t pos, Type weight = 1 );
 
    /// Get the number of bins
    Int_t GetNBins() const;

--- a/plug-ins/include/SH1.icc
+++ b/plug-ins/include/SH1.icc
@@ -114,7 +114,7 @@ SH1< Type >::~SH1() {
  * @param weight The amount with which the bin should be filled
  */
 template< typename Type >
-void SH1< Type >::Fill( Double_t pos, Type weight ) throw( SError ) {
+void SH1< Type >::Fill( Double_t pos, Type weight ) {
 
    // Check if the given parameters make sense:
    if( TMath::IsNaN( pos ) || TMath::IsNaN( weight ) ) {

--- a/plug-ins/include/SInputVariables.h
+++ b/plug-ins/include/SInputVariables.h
@@ -38,7 +38,7 @@ protected:
    /// Connect an input variable
    template< typename T >
    bool ConnectVariable( const char* treeName, const char* branchName,
-                         T& variable ) throw ( SError );
+                         T& variable );
 
 private:
    ParentType* m_parent; ///< Pointer to the parent cycle

--- a/plug-ins/include/SInputVariables.icc
+++ b/plug-ins/include/SInputVariables.icc
@@ -43,7 +43,7 @@ template< typename T >
 bool SInputVariables< ParentType >::
 ConnectVariable( const char* treeName,
                  const char* branchName,
-                 T& variable ) throw ( SError ) {
+                 T& variable ) {
 
    return m_parent->template ConnectVariable( treeName, branchName, variable );
 }

--- a/plug-ins/include/SOutputVariables.h
+++ b/plug-ins/include/SOutputVariables.h
@@ -45,7 +45,7 @@ protected:
    /// Declare an output variable
    template< typename T >
    TBranch* DeclareVariable( T& obj, const char* name,
-                             const char* treeName = 0 ) throw( SError );
+                             const char* treeName = 0 );
 
 private:
    ParentType* m_parent; ///< Pointer to the parent cycle

--- a/plug-ins/include/SOutputVariables.icc
+++ b/plug-ins/include/SOutputVariables.icc
@@ -37,7 +37,7 @@ template< class ParentType >
 template< typename T >
 TBranch* SOutputVariables< ParentType >::
 DeclareVariable( T& obj, const char* name,
-                 const char* treeName ) throw( SError ) {
+                 const char* treeName ) {
 
    return m_parent->template DeclareVariable( obj, name, treeName );
 }

--- a/plug-ins/include/SSummedVar.h
+++ b/plug-ins/include/SSummedVar.h
@@ -112,7 +112,7 @@ public:
 
 private:
    /// Function for accessing the internal object
-   ProofSummedVar< Type >* GetObject() const throw( SError );
+   ProofSummedVar< Type >* GetObject() const;
 
    TString                         m_objName; ///< Name of the object
    ISCycleBaseHist*                m_parent; ///< Pointer to the parent cycle

--- a/plug-ins/include/SSummedVar.icc
+++ b/plug-ins/include/SSummedVar.icc
@@ -315,7 +315,7 @@ const Type* SSummedVar< Type >::GetPointer() const {
  * @returns The helper object that should be used by the object currently
  */
 template< class Type >
-ProofSummedVar< Type >* SSummedVar< Type >::GetObject() const throw( SError ) {
+ProofSummedVar< Type >* SSummedVar< Type >::GetObject() const {
 
    //
    // Try to get an already existing object from the output list:

--- a/plug-ins/include/SToolBase.h
+++ b/plug-ins/include/SToolBase.h
@@ -62,18 +62,18 @@ protected:
    /// Function placing a ROOT object in the output file
    template< class T > T* Book( const T& histo,
                                 const char* directory = 0,
-                                Bool_t inFile = kFALSE ) throw( SError );
+                                Bool_t inFile = kFALSE );
    /// Function searching for a ROOT object in the output file
    template< class T > T*
    Retrieve( const char* name, const char* directory = 0,
-             Bool_t outputOnly = kFALSE ) throw( SError );
+             Bool_t outputOnly = kFALSE );
    /// Function retrieving all ROOT objects of this name from the input file
    template< class T >
    std::vector< T* > RetrieveAll( const char* name,
-                                  const char* directory = 0 ) throw( SError );
+                                  const char* directory = 0 );
    /// Function for persistifying a ROOT object to the output
    void WriteObj( const TObject& obj,
-                  const char* directory = 0 ) throw( SError );
+                  const char* directory = 0 );
    /// Function searching for 1-dimensional histograms in the output file
    TH1* Hist( const char* name, const char* dir = 0 );
    //@}
@@ -84,23 +84,23 @@ public:
    /// Connect an input variable
    template< typename T >
    bool ConnectVariable( const char* treeName, const char* branchName,
-                         T& variable ) throw ( SError );
+                         T& variable );
    /// Declare an output variable
    template< typename T >
    TBranch* DeclareVariable( T& obj, const char* name,
-                             const char* treeName = 0 ) throw( SError );
+                             const char* treeName = 0 );
    /// Access one of the metadata trees
-   virtual TTree* GetMetadataTree( const char* name ) const throw( SError );
+   virtual TTree* GetMetadataTree( const char* name ) const;
    /// Access one of the input metadata trees
    virtual TTree*
-   GetInputMetadataTree( const char* name ) const throw( SError );
+   GetInputMetadataTree( const char* name ) const;
    /// Access one of the output metadata trees
    virtual TTree*
-   GetOutputMetadataTree( const char* name ) const throw( SError );
+   GetOutputMetadataTree( const char* name ) const;
    /// Access one of the input trees
-   virtual TTree* GetInputTree( const char* treeName ) const throw( SError );
+   virtual TTree* GetInputTree( const char* treeName ) const;
    /// Access one of the output trees
-   virtual TTree* GetOutputTree( const char* treeName ) const throw( SError );
+   virtual TTree* GetOutputTree( const char* treeName ) const;
    //@}
 
 protected:

--- a/plug-ins/include/SToolBase.icc
+++ b/plug-ins/include/SToolBase.icc
@@ -63,7 +63,7 @@ template< class Type >
 template< class T >
 T* SToolBaseT< Type >::Book( const T& histo,
                              const char* directory,
-                             Bool_t inFile ) throw( SError ) {
+                             Bool_t inFile ) {
 
    return GetParent()->template Book( histo, directory, inFile );
 }
@@ -75,7 +75,7 @@ template< class Type >
 template< class T >
 T* SToolBaseT< Type >::Retrieve( const char* name,
                                  const char* directory,
-                                 Bool_t outputOnly ) throw( SError ) {
+                                 Bool_t outputOnly ) {
 
    return GetParent()->template Retrieve< T >( name, directory, outputOnly );
 }
@@ -87,7 +87,7 @@ template< class Type >
 template< class T >
 std::vector< T* >
 SToolBaseT< Type >::RetrieveAll( const char* name,
-                                 const char* directory ) throw( SError ) {
+                                 const char* directory ) {
 
    return GetParent()->template RetrieveAll< T >( name, directory );
 }
@@ -97,7 +97,7 @@ SToolBaseT< Type >::RetrieveAll( const char* name,
  */
 template< class Type >
 void SToolBaseT< Type >::WriteObj( const TObject& obj,
-                                   const char* directory ) throw( SError ) {
+                                   const char* directory ) {
 
    GetParent()->WriteObj( obj, directory );
    return;
@@ -119,7 +119,7 @@ template< class Type >
 template< typename T >
 bool SToolBaseT< Type >::ConnectVariable( const char* treeName,
                                           const char* branchName,
-                                          T& variable ) throw ( SError ) {
+                                          T& variable ) {
 
    return GetParent()->template ConnectVariable( treeName, branchName,
                                                  variable );
@@ -132,7 +132,7 @@ template< class Type >
 template< typename T >
 TBranch*
 SToolBaseT< Type >::DeclareVariable( T& obj, const char* name,
-                                     const char* treeName ) throw( SError ) {
+                                     const char* treeName ) {
 
    return GetParent()->template DeclareVariable( obj, name, treeName );
 }
@@ -142,7 +142,7 @@ SToolBaseT< Type >::DeclareVariable( T& obj, const char* name,
  */
 template< class Type >
 TTree* SToolBaseT< Type >::
-GetMetadataTree( const char* name ) const throw( SError ) {
+GetMetadataTree( const char* name ) const {
 
    return GetParent()->GetMetadataTree( name );
 }
@@ -152,7 +152,7 @@ GetMetadataTree( const char* name ) const throw( SError ) {
  */
 template< class Type >
 TTree* SToolBaseT< Type >::
-GetInputMetadataTree( const char* name ) const throw( SError ) {
+GetInputMetadataTree( const char* name ) const {
 
    return GetParent()->GetInputMetadataTree( name );
 }
@@ -162,7 +162,7 @@ GetInputMetadataTree( const char* name ) const throw( SError ) {
  */
 template< class Type >
 TTree* SToolBaseT< Type >::
-GetOutputMetadataTree( const char* name ) const throw( SError ) {
+GetOutputMetadataTree( const char* name ) const {
 
    return GetParent()->GetOutputMetadataTree( name );
 }
@@ -172,7 +172,7 @@ GetOutputMetadataTree( const char* name ) const throw( SError ) {
  */
 template< class Type >
 TTree* SToolBaseT< Type >::
-GetInputTree( const char* treeName ) const throw( SError ) {
+GetInputTree( const char* treeName ) const {
 
    return GetParent()->GetInputTree( treeName );
 }
@@ -182,7 +182,7 @@ GetInputTree( const char* treeName ) const throw( SError ) {
  */
 template< class Type >
 TTree* SToolBaseT< Type >::
-GetOutputTree( const char* treeName ) const throw( SError ) {
+GetOutputTree( const char* treeName ) const {
 
    return GetParent()->GetOutputTree( treeName );
 }

--- a/python/CycleCreators.py
+++ b/python/CycleCreators.py
@@ -66,20 +66,20 @@ public:
    ~%(class)-s();
 
    /// Function called at the beginning of the cycle
-   virtual void BeginCycle() throw( SError );
+   virtual void BeginCycle();
    /// Function called at the end of the cycle
-   virtual void EndCycle() throw( SError );
+   virtual void EndCycle();
 
    /// Function called at the beginning of a new input data
-   virtual void BeginInputData( const SInputData& ) throw( SError );
+   virtual void BeginInputData( const SInputData& );
    /// Function called after finishing to process an input data
-   virtual void EndInputData  ( const SInputData& ) throw( SError );
+   virtual void EndInputData  ( const SInputData& );
 
    /// Function called after opening each new input file
-   virtual void BeginInputFile( const SInputData& ) throw( SError );
+   virtual void BeginInputFile( const SInputData& );
 
    /// Function called for every event
-   virtual void ExecuteEvent( const SInputData&, Double_t ) throw( SError );
+   virtual void ExecuteEvent( const SInputData&, Double_t );
 
 private:
    //
@@ -126,20 +126,20 @@ namespace %(ns)-s {
       ~%(class)-s();
 
       /// Function called at the beginning of the cycle
-      virtual void BeginCycle() throw( SError );
+      virtual void BeginCycle();
       /// Function called at the end of the cycle
-      virtual void EndCycle() throw( SError );
+      virtual void EndCycle();
 
       /// Function called at the beginning of a new input data
-      virtual void BeginInputData( const SInputData& ) throw( SError );
+      virtual void BeginInputData( const SInputData& );
       /// Function called after finishing to process an input data
-      virtual void EndInputData  ( const SInputData& ) throw( SError );
+      virtual void EndInputData  ( const SInputData& );
 
       /// Function called after opening each new input file
-      virtual void BeginInputFile( const SInputData& ) throw( SError );
+      virtual void BeginInputFile( const SInputData& );
 
       /// Function called for every event
-      virtual void ExecuteEvent( const SInputData&, Double_t ) throw( SError );
+      virtual void ExecuteEvent( const SInputData&, Double_t );
 
    private:
       //
@@ -228,37 +228,37 @@ ClassImp( %(class)-s );
 
 }
 
-void %(class)-s::BeginCycle() throw( SError ) {
+void %(class)-s::BeginCycle() {
 
    return;
 
 }
 
-void %(class)-s::EndCycle() throw( SError ) {
+void %(class)-s::EndCycle() {
 
    return;
 
 }
 
-void %(class)-s::BeginInputData( const SInputData& ) throw( SError ) {
+void %(class)-s::BeginInputData( const SInputData& ) {
 
    return;
 
 }
 
-void %(class)-s::EndInputData( const SInputData& ) throw( SError ) {
+void %(class)-s::EndInputData( const SInputData& ) {
 
    return;
 
 }
 
-void %(class)-s::BeginInputFile( const SInputData& ) throw( SError ) {
+void %(class)-s::BeginInputFile( const SInputData& ) {
 
    return;
 
 }
 
-void %(class)-s::ExecuteEvent( const SInputData&, Double_t ) throw( SError ) {
+void %(class)-s::ExecuteEvent( const SInputData&, Double_t ) {
 
    return;
 
@@ -289,37 +289,37 @@ namespace %(ns)-s {
 
    }
 
-   void %(class)-s::BeginCycle() throw( SError ) {
+   void %(class)-s::BeginCycle() {
 
       return;
 
    }
 
-   void %(class)-s::EndCycle() throw( SError ) {
+   void %(class)-s::EndCycle() {
 
       return;
 
    }
 
-   void %(class)-s::BeginInputData( const SInputData& ) throw( SError ) {
+   void %(class)-s::BeginInputData( const SInputData& ) {
 
       return;
 
    }
 
-   void %(class)-s::EndInputData( const SInputData& ) throw( SError ) {
+   void %(class)-s::EndInputData( const SInputData& ) {
 
       return;
 
    }
 
-   void %(class)-s::BeginInputFile( const SInputData& ) throw( SError ) {
+   void %(class)-s::BeginInputFile( const SInputData& ) {
 
       return;
 
    }
 
-   void %(class)-s::ExecuteEvent( const SInputData&, Double_t ) throw( SError ) {
+   void %(class)-s::ExecuteEvent( const SInputData&, Double_t ) {
 
       return;
 

--- a/user/include/FirstCycle.h
+++ b/user/include/FirstCycle.h
@@ -32,18 +32,18 @@ class FirstCycle : public SCycleBase {
 public:
    FirstCycle();
 
-   virtual void BeginCycle() throw( SError );
-   virtual void EndCycle() throw( SError );
+   virtual void BeginCycle();
+   virtual void EndCycle();
 
-   virtual void BeginInputData( const SInputData& ) throw( SError );
-   virtual void EndInputData  ( const SInputData& ) throw( SError );
+   virtual void BeginInputData( const SInputData& );
+   virtual void EndInputData  ( const SInputData& );
 
-   virtual void BeginMasterInputData( const SInputData& ) throw( SError );
-   virtual void EndMasterInputData  ( const SInputData& ) throw( SError );
+   virtual void BeginMasterInputData( const SInputData& );
+   virtual void EndMasterInputData  ( const SInputData& );
 
-   virtual void BeginInputFile( const SInputData& ) throw( SError );
+   virtual void BeginInputFile( const SInputData& );
 
-   virtual void ExecuteEvent( const SInputData&, Double_t weight ) throw( SError );
+   virtual void ExecuteEvent( const SInputData&, Double_t weight );
 
 private:
    //

--- a/user/include/SecondCycle.h
+++ b/user/include/SecondCycle.h
@@ -31,15 +31,15 @@ class SecondCycle : public SCycleBase {
 public:
    SecondCycle();
 
-   virtual void BeginCycle() throw( SError );
-   virtual void EndCycle() throw( SError );
+   virtual void BeginCycle();
+   virtual void EndCycle();
 
-   virtual void BeginInputFile( const SInputData& ) throw( SError );
+   virtual void BeginInputFile( const SInputData& );
 
-   virtual void BeginInputData( const SInputData& ) throw( SError );
-   virtual void EndInputData  ( const SInputData& ) throw( SError );
+   virtual void BeginInputData( const SInputData& );
+   virtual void EndInputData  ( const SInputData& );
 
-   virtual void ExecuteEvent( const SInputData&, Double_t weight ) throw( SError );
+   virtual void ExecuteEvent( const SInputData&, Double_t weight );
 
 private:
    std::string m_FirstCycleTreeName;

--- a/user/src/FirstCycle.cxx
+++ b/user/src/FirstCycle.cxx
@@ -43,7 +43,7 @@ FirstCycle::FirstCycle()
    DeclareProperty( "MetaTreeName", m_metaTreeName );
 }
 
-void FirstCycle::BeginCycle() throw( SError ) {
+void FirstCycle::BeginCycle() {
 
    //
    // Print the properties specified in the XML configuration:
@@ -95,12 +95,12 @@ void FirstCycle::BeginCycle() throw( SError ) {
    return;
 }
 
-void FirstCycle::EndCycle() throw( SError ) {
+void FirstCycle::EndCycle() {
 
    return;
 }
 
-void FirstCycle::BeginInputFile( const SInputData& )  throw( SError ) {
+void FirstCycle::BeginInputFile( const SInputData& )  {
 
    //
    // Connect the input variables:
@@ -114,7 +114,7 @@ void FirstCycle::BeginInputFile( const SInputData& )  throw( SError ) {
    return;
 }
 
-void FirstCycle::BeginInputData( const SInputData& ) throw( SError ) {
+void FirstCycle::BeginInputData( const SInputData& ) {
 
    //
    // Declare the output variables:
@@ -149,7 +149,7 @@ void FirstCycle::BeginInputData( const SInputData& ) throw( SError ) {
    return;
 }
 
-void FirstCycle::EndInputData( const SInputData& ) throw( SError ) {
+void FirstCycle::EndInputData( const SInputData& ) {
 
    static const Int_t n = 5;
    Float_t x_array[ n ] = { 0.0, 1.0, 2.0, 3.0, 4.0 };
@@ -161,12 +161,12 @@ void FirstCycle::EndInputData( const SInputData& ) throw( SError ) {
    return;
 }
 
-void FirstCycle::BeginMasterInputData( const SInputData& ) throw( SError ) {
+void FirstCycle::BeginMasterInputData( const SInputData& ) {
 
    return;
 }
 
-void FirstCycle::EndMasterInputData( const SInputData& ) throw( SError ) {
+void FirstCycle::EndMasterInputData( const SInputData& ) {
 
    m_logger << INFO << "Number of all processed events: "
             << *m_allEvents << " " << ( m_test->size() > 0 ? ( *m_test )[ 0 ] : 0 )
@@ -178,7 +178,7 @@ void FirstCycle::EndMasterInputData( const SInputData& ) throw( SError ) {
    return;
 }
 
-void FirstCycle::ExecuteEvent( const SInputData&, Double_t weight ) throw( SError ) {
+void FirstCycle::ExecuteEvent( const SInputData&, Double_t weight ) {
 
    //
    // If you have vectors (or any other type of containers) in the output,

--- a/user/src/SecondCycle.cxx
+++ b/user/src/SecondCycle.cxx
@@ -28,27 +28,27 @@ SecondCycle::SecondCycle()
                     m_FirstCycleTreeName = "FirstCycleTree" );
 }
 
-void SecondCycle::BeginCycle() throw( SError ) {
+void SecondCycle::BeginCycle() {
 
    return;
 }
 
-void SecondCycle::EndCycle() throw( SError ) {
+void SecondCycle::EndCycle() {
 
    return;
 }
 
-void SecondCycle::BeginInputData( const SInputData& ) throw( SError ) {
+void SecondCycle::BeginInputData( const SInputData& ) {
 
    return;
 }
 
-void SecondCycle::EndInputData( const SInputData& ) throw( SError ) {
+void SecondCycle::EndInputData( const SInputData& ) {
 
    return;
 }
 
-void SecondCycle::BeginInputFile( const SInputData& ) throw( SError ) {
+void SecondCycle::BeginInputFile( const SInputData& ) {
 
    //
    // Connect the input variables:
@@ -78,7 +78,7 @@ void SecondCycle::BeginInputFile( const SInputData& ) throw( SError ) {
 }
 
 void SecondCycle::ExecuteEvent( const SInputData&,
-                                Double_t weight ) throw( SError ) {
+                                Double_t weight ) {
 
    // Loop over the simple vector:
    for( std::vector< double >::const_iterator it = m_El_p_T->begin();


### PR DESCRIPTION
CMSSW_10_2_X will use GCC7 by default, which now supports the C++17 standard. This includes dropping support for `throw` in method declarations (was already old in C++14) in favour of `noexcept()`. Whilst I could have replaced all the `throw(SError)` with `noexcept(false)`, it doesn't add any extra information (see https://stackoverflow.com/questions/16244313/does-adding-noexceptfalse-benefit-the-code-in-any-way). So I've removed all occurrences of it.

I tested it in the following archs:

- slc6_amd64_gcc730
- slc6_amd64_gcc630
- slc6_amd64_gcc530

running a test analysis module, and all seems OK. So it should be fine if one sets up a new 80X or 94X area. 
I also tried with an incorrect branch name to trigger an exception, and it prints out:

```
terminate called after throwing an instance of 'std::runtime_error'
  what():  Could not find branch 'slimmedElectrons' in tree 'AnalysisTree'
Aborted
```
and then quits, which seems acceptable.