### PR TITLE
Add time estimate to screen output 

### DIFF
--- a/core/include/SCycleBaseExec.h
+++ b/core/include/SCycleBaseExec.h
@@ -16,6 +16,7 @@
 
 // STL include(s):
 #include <vector>
+#include <chrono>
 
 // ROOT include(s):
 #include <TSelector.h>
@@ -163,6 +164,11 @@ private:
    SInputData*           m_inputData; ///< Pointer to the currently active ID
    /// List of all the event-level output TTree-s
    std::vector< TTree* > m_outputTrees;
+
+   /// For timing events
+   typedef std::chrono::high_resolution_clock clock_;
+   typedef std::chrono::duration<double, std::ratio<1> > second_;
+   std::chrono::time_point<clock_> m_timeStart;
 
 #ifndef DOXYGEN_IGNORE
    ClassDef( SCycleBaseExec, 0 )

--- a/core/src/SCycleBaseExec.cxx
+++ b/core/src/SCycleBaseExec.cxx
@@ -288,7 +288,8 @@ Bool_t SCycleBaseExec::Process( Long64_t entry ) {
                << ( m_nProcessedEvents - 1 ) << " / "
                << total_events
                << " events processed so far, ~ "
-               << TString::Format("%.2g" , time_remaining) << " " << time_unit << " left)"
+               << TString::Format("%.2g" , time_remaining)
+               << " " << time_unit << " left)"
                << SLogger::endmsg;
    }
 

--- a/core/src/SCycleBaseExec.cxx
+++ b/core/src/SCycleBaseExec.cxx
@@ -13,6 +13,7 @@
 // ROOT include(s):
 #include <TTree.h>
 #include <TSystem.h>
+#include <TString.h>
 
 // Local include(s):
 #include "../include/SCycleBaseExec.h"
@@ -62,6 +63,7 @@ void SCycleBaseExec::Begin( TTree* ) {
       // Let the user initialize his/her code:
       this->BeginMasterInputData( *m_inputData );
 
+      m_timeStart = clock_::now();
    } catch( const SError& error ) {
       REPORT_FATAL( "Exception caught with message: " << error.what() );
       throw;
@@ -114,6 +116,7 @@ void SCycleBaseExec::SlaveBegin( TTree* ) {
    m_nProcessedEvents = 0;
    m_nSkippedEvents = 0;
    m_firstInit = kTRUE;
+   m_timeStart = clock_::now();
 
    // Print what just happened:
    m_logger << ::INFO << "Initialised InputData \"" << m_inputData->GetType()
@@ -262,16 +265,31 @@ Bool_t SCycleBaseExec::Process( Long64_t entry ) {
 
    ++m_nProcessedEvents;
    if( ! ( m_nProcessedEvents % 1000 ) ) {
+      double time_elapsed = std::chrono::duration_cast<std::chrono::seconds>(
+                             clock_::now() - m_timeStart).count();
+      int total_events = ( m_inputData->GetNEventsMax() < 0 ?
+                           m_inputData->GetEventsTotal() :
+                           m_inputData->GetNEventsMax() );
+      int remaining_events = total_events - m_nProcessedEvents;
+      double time_remaining = remaining_events * (time_elapsed/m_nProcessedEvents);
+      std::string time_unit = "seconds";
+      if (time_remaining > 3600) {
+         time_remaining /= 3600;
+         time_unit = "hours";
+      } else if (time_remaining > 60) {
+         time_remaining /= 60;
+         time_unit = "minutes";
+      }
       // Only print these messages in local mode in INFO level. In PROOF mode
       // they're only needed for debugging.
       m_logger << ( GetConfig().GetRunMode() == SCycleConfig::LOCAL ? ::INFO :
                     ::DEBUG )
                << "Processing entry: " << entry << " ("
                << ( m_nProcessedEvents - 1 ) << " / "
-               << ( m_inputData->GetNEventsMax() < 0 ?
-                    m_inputData->GetEventsTotal() :
-                    m_inputData->GetNEventsMax() )
-               << " events processed so far)" << SLogger::endmsg;
+               << total_events
+               << " events processed so far, ~ "
+               << TString::Format("%.2g" , time_remaining) << " " << time_unit << " left)"
+               << SLogger::endmsg;
    }
 
    // Return gracefully:


### PR DESCRIPTION
Add an estimate every 1K events of how long left to run. Doesn't impact runtime, and may be useful for users.
New output looks like:

```
 ( INFO  )  SCycleBaseExec     : Processing entry: 10512 (60999 / 100000 events processed so far, ~ 1.1 minutes left)
 ( INFO  )  SCycleBaseExec     : Processing entry: 11512 (61999 / 100000 events processed so far, ~ 1 minutes left)
 ( INFO  )  SCycleBaseExec     : Processing entry: 12512 (62999 / 100000 events processed so far, ~ 1 minutes left)
 ( INFO  )  SCycleBaseExec     : Processing entry: 13512 (63999 / 100000 events processed so far, ~ 58 seconds left)
 ( INFO  )  SCycleBaseExec     : Processing entry: 14512 (64999 / 100000 events processed so far, ~ 57 seconds left)
```

(it will auto switch to "X hours left" if > 60 minutes)